### PR TITLE
fix: Avoid service exit due to incorrect input formats in stdio

### DIFF
--- a/transport/stdio_server.go
+++ b/transport/stdio_server.go
@@ -95,7 +95,7 @@ func (t *stdioServerTransport) receive(ctx context.Context) {
 		default:
 			if err := t.receiver.Receive(ctx, stdioSessionID, s.Bytes()); err != nil {
 				t.logger.Errorf("receiver failed: %v", err)
-				return
+				continue
 			}
 		}
 	}


### PR DESCRIPTION
input:error json
output: [Error] receiver failed: json unmarshal error: data=, error: "Syntax error no sources available, the input json is empty: errors.SyntaxError{Pos:0, Src:\"\", Code:0x1, Msg:\"\"}"