### PR TITLE
fix: Send content type for sse transport client request

### DIFF
--- a/transport/sse_client.go
+++ b/transport/sse_client.go
@@ -201,6 +201,8 @@ func (t *sseClientTransport) Send(ctx context.Context, msg Message) error {
 		return fmt.Errorf("failed to create request: %w", err)
 	}
 
+	req.Header.Set("Content-Type", "application/json")
+
 	if resp, err = t.client.Do(req); err != nil {
 		return fmt.Errorf("failed to send message: %w", err)
 	}


### PR DESCRIPTION
The official server sdk sse implementation expects content type for requests:
https://github.com/modelcontextprotocol/typescript-sdk/blob/main/src/server/sse.ts#L92