### PR TITLE
fix: Add Debug Logger to display debug information

### DIFF
--- a/pkg/log.go
+++ b/pkg/log.go
@@ -21,6 +21,10 @@ var DefaultLogger Logger = &defaultLogger{
 	logLevel: LogLevelInfo,
 }
 
+var DebugLogger Logger = &defaultLogger{
+	logLevel: LogLevelDebug,
+}
+
 type defaultLogger struct {
 	logLevel LogLevel
 }


### PR DESCRIPTION
When initializing the NewSSEClientTransport, you can enable debug mode for troubleshooting or logging purposes.