### PR TITLE
fix:filter empty messages

### DIFF
--- a/transport/stdio_server.go
+++ b/transport/stdio_server.go
@@ -5,10 +5,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"github.com/ThinkInAIXYZ/go-mcp/pkg"
 	"io"
 	"os"
-
-	"github.com/ThinkInAIXYZ/go-mcp/pkg"
+	"strings"
 )
 
 const stdioSessionID = "stdio"
@@ -94,7 +94,8 @@ func (t *stdioServerTransport) receive(ctx context.Context) {
 			return
 		default:
 			// filter empty messages
-			if s.Text() == "" || s.Text() == " " {
+			// filter space messages and \t messages
+			if len(strings.TrimFunc(s.Text(), func(r rune) bool { return r == ' ' || r == '\t' })) == 0 {
 				continue
 			}
 			if err := t.receiver.Receive(ctx, stdioSessionID, s.Bytes()); err != nil {

--- a/transport/stdio_server.go
+++ b/transport/stdio_server.go
@@ -93,6 +93,10 @@ func (t *stdioServerTransport) receive(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		default:
+			// filter empty messages
+			if s.Text() == "" || s.Text() == " " {
+				continue
+			}
 			if err := t.receiver.Receive(ctx, stdioSessionID, s.Bytes()); err != nil {
 				t.logger.Errorf("receiver failed: %v", err)
 				continue

--- a/transport/stdio_server.go
+++ b/transport/stdio_server.go
@@ -6,9 +6,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/ThinkInAIXYZ/go-mcp/pkg"
 	"io"
 	"os"
+
+	"github.com/ThinkInAIXYZ/go-mcp/pkg"
 )
 
 const stdioSessionID = "stdio"

--- a/transport/stdio_server.go
+++ b/transport/stdio_server.go
@@ -2,13 +2,13 @@ package transport
 
 import (
 	"bufio"
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
 	"github.com/ThinkInAIXYZ/go-mcp/pkg"
 	"io"
 	"os"
-	"strings"
 )
 
 const stdioSessionID = "stdio"
@@ -95,7 +95,8 @@ func (t *stdioServerTransport) receive(ctx context.Context) {
 		default:
 			// filter empty messages
 			// filter space messages and \t messages
-			if len(strings.TrimFunc(s.Text(), func(r rune) bool { return r == ' ' || r == '\t' })) == 0 {
+			if len(bytes.TrimFunc(s.Bytes(), func(r rune) bool { return r == ' ' || r == '\t' })) == 0 {
+				t.logger.Debugf("skipping empty message")
 				continue
 			}
 			if err := t.receiver.Receive(ctx, stdioSessionID, s.Bytes()); err != nil {


### PR DESCRIPTION
Avoid printing error logs when inputting empty data