### PR TITLE
为message接口加入响应返回

### DIFF
--- a/examples/everything/main.go
+++ b/examples/everything/main.go
@@ -98,7 +98,7 @@ func getTransport() (t transport.ServerTransport) {
 	} else {
 		addr := fmt.Sprintf("127.0.0.1:%s", port)
 		log.Printf("start current time mcp server with sse transport, listen %s", addr)
-		t, _ = transport.NewSSEServerTransport(addr)
+		t, _ = transport.NewSSEServerTransport(addr, transport.WithSSEServerTransportOptionOpenResponse(true))
 	}
 
 	return t

--- a/server/send.go
+++ b/server/send.go
@@ -3,7 +3,6 @@ package server
 import (
 	"context"
 	"fmt"
-
 	"github.com/bytedance/sonic"
 
 	"github.com/ThinkInAIXYZ/go-mcp/protocol"

--- a/transport/stdio_server.go
+++ b/transport/stdio_server.go
@@ -93,6 +93,10 @@ func (t *stdioServerTransport) receive(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		default:
+			// filter empty messages
+			if s.Text() == "" || s.Text() == " " {
+				continue
+			}
 			if err := t.receiver.Receive(ctx, stdioSessionID, s.Bytes()); err != nil {
 				t.logger.Errorf("receiver failed: %v", err)
 				continue


### PR DESCRIPTION
当前框架中在sse模型下，请求message接口但是没有结果响应，只能通过sse获取响应。
本次提交加入message也可以返回与sse一样的响应，本功能与mark3labs/mcp-go一致。