### PR TITLE
Support arm64 architecture on JSON implementations

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -30,7 +30,7 @@ jobs:
     #   - https://gh.io/supported-runners-and-hardware-resources
     #   - https://gh.io/using-larger-runners (GitHub.com only)
     # Consider using larger runners or machines with greater resources for possible analysis time improvements.
-    runs-on: ${{ (matrix.language == 'swift' && 'macos-latest') || 'ubuntu-latest' }}
+    runs-on: ${{ matrix.runner }}
     permissions:
       # required for all workflows
       security-events: write
@@ -45,6 +45,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        runner: [ubuntu-24.04, ubuntu-24.04-arm]
         include:
         - language: go
           build-mode: autobuild

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,8 +11,12 @@ on:
 
 jobs:
   resolve-modules:
+    strategy:
+      fail-fast: false
+      matrix:
+        runner: [ubuntu-24.04, ubuntu-24.04-arm]
     name: resolve module
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.runner }}
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
@@ -24,7 +28,7 @@ jobs:
 
   lint:
     name: lint module
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.runner }}
     needs: resolve-modules
     strategy:
       matrix: ${{ fromJson(needs.resolve-modules.outputs.matrix) }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,8 +26,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go-version: [1.18,1.22]
-    runs-on: ubuntu-latest
+        runner: [ubuntu-24.04, ubuntu-24.04-arm]
+        go-version: [1.18,1.24]
+    runs-on: ${{ matrix.runner }}
     steps:
       - name: Set up Go
         uses: actions/setup-go@v5

--- a/client/client.go
+++ b/client/client.go
@@ -6,7 +6,6 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/bytedance/sonic"
 	cmap "github.com/orcaman/concurrent-map/v2"
 
 	"github.com/ThinkInAIXYZ/go-mcp/pkg"
@@ -171,7 +170,7 @@ func (client *Client) Close() error {
 }
 
 func defaultNotifyHandler(logger pkg.Logger, notify interface{}) error {
-	b, err := sonic.Marshal(notify)
+	b, err := pkg.JSONMarshal(notify)
 	if err != nil {
 		return err
 	}

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -9,8 +9,6 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/bytedance/sonic"
-
 	"github.com/ThinkInAIXYZ/go-mcp/pkg"
 	"github.com/ThinkInAIXYZ/go-mcp/protocol"
 	"github.com/ThinkInAIXYZ/go-mcp/transport"
@@ -192,7 +190,7 @@ func TestClientCall(t *testing.T) {
 					return
 				}
 
-				respBytes, err := sonic.Marshal(protocol.NewJSONRPCSuccessResponse(jsonrpcReq.ID, tt.expectedResponse))
+				respBytes, err := pkg.JSONMarshal(protocol.NewJSONRPCSuccessResponse(jsonrpcReq.ID, tt.expectedResponse))
 				if err != nil {
 					t.Errorf("Json Marshal: %+v", err)
 					return
@@ -285,7 +283,7 @@ func testClientInit(t *testing.T, in io.ReadWriter, out io.ReadWriter, outScan *
 			ProtocolVersion: protocol.Version,
 		}
 
-		respBytes, err := sonic.Marshal(protocol.NewJSONRPCSuccessResponse(jsonrpcReq.ID, resp))
+		respBytes, err := pkg.JSONMarshal(protocol.NewJSONRPCSuccessResponse(jsonrpcReq.ID, resp))
 		if err != nil {
 			t.Errorf("Json Marshal: %+v", err)
 			return

--- a/client/send.go
+++ b/client/send.go
@@ -4,8 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/bytedance/sonic"
-
+	"github.com/ThinkInAIXYZ/go-mcp/pkg"
 	"github.com/ThinkInAIXYZ/go-mcp/protocol"
 )
 
@@ -16,7 +15,7 @@ func (client *Client) sendMsgWithRequest(ctx context.Context, requestID protocol
 
 	req := protocol.NewJSONRPCRequest(requestID, method, params)
 
-	message, err := sonic.Marshal(req)
+	message, err := pkg.JSONMarshal(req)
 	if err != nil {
 		return err
 	}
@@ -34,7 +33,7 @@ func (client *Client) sendMsgWithResponse(ctx context.Context, requestID protoco
 
 	resp := protocol.NewJSONRPCSuccessResponse(requestID, result)
 
-	message, err := sonic.Marshal(resp)
+	message, err := pkg.JSONMarshal(resp)
 	if err != nil {
 		return err
 	}
@@ -48,7 +47,7 @@ func (client *Client) sendMsgWithResponse(ctx context.Context, requestID protoco
 func (client *Client) sendMsgWithNotification(ctx context.Context, method protocol.Method, params protocol.ClientNotify) error {
 	notify := protocol.NewJSONRPCNotification(method, params)
 
-	message, err := sonic.Marshal(notify)
+	message, err := pkg.JSONMarshal(notify)
 	if err != nil {
 		return err
 	}
@@ -66,7 +65,7 @@ func (client *Client) sendMsgWithError(ctx context.Context, requestID protocol.R
 
 	resp := protocol.NewJSONRPCErrorResponse(requestID, code, msg)
 
-	message, err := sonic.Marshal(resp)
+	message, err := pkg.JSONMarshal(resp)
 	if err != nil {
 		return err
 	}

--- a/go.mod
+++ b/go.mod
@@ -1,9 +1,12 @@
 module github.com/ThinkInAIXYZ/go-mcp
 
-go 1.18
+go 1.24
+
+toolchain go1.24.2
 
 require (
 	github.com/bytedance/sonic v1.13.2
+	github.com/go-json-experiment/json v0.0.0-20250223041408-d3c622f1b874
 	github.com/google/uuid v1.6.0
 	github.com/orcaman/concurrent-map/v2 v2.0.1
 	github.com/stretchr/testify v1.10.0

--- a/go.sum
+++ b/go.sum
@@ -9,6 +9,8 @@ github.com/cloudwego/iasm v0.2.0/go.mod h1:8rXZaNYT2n95jn+zTI1sDr+IgcD2GVs0nlbbQ
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/go-json-experiment/json v0.0.0-20250223041408-d3c622f1b874 h1:F8d1AJ6M9UQCavhwmO6ZsrYLfG8zVFWfEfMS2MXPkSY=
+github.com/go-json-experiment/json v0.0.0-20250223041408-d3c622f1b874/go.mod h1:TiCD2a1pcmjd7YnhGH0f/zKNcCD06B029pHhzV23c2M=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/klauspost/cpuid/v2 v2.0.9 h1:lgaqFMSdTdQYdZ04uHyN2d/eKdOMyi2YLSvlQIBFYa4=

--- a/hack/resolve-modules.sh
+++ b/hack/resolve-modules.sh
@@ -36,4 +36,18 @@ for mod in $all_modules; do
 	fi
 done
 
-echo "::set-output name=matrix::{\"include\":[${PATHS%?}]}"
+MACHINE_ARCH="$(uname -m)"
+RUNNER=""
+case ${MACHINE_ARCH} in
+  x86_64)
+    RUNNER="ubuntu-latest"
+    ;;
+  arm64)
+    RUNNER="ubuntu-24.04-arm"
+    ;;
+  *)
+    echo "Unsupported architecture $(go env GOARCH)"
+    exit 1
+esac
+
+echo "::set-output name=matrix::{\"include\":[${PATHS%?}],\"runner\":[${RUNNER}]}"

--- a/pkg/errors.go
+++ b/pkg/errors.go
@@ -11,6 +11,7 @@ var (
 	ErrLackResponseChan          = errors.New("lack response chan")
 	ErrDuplicateResponseReceived = errors.New("duplicate response received")
 	ErrMethodNotSupport          = errors.New("method not support")
+	ErrJSONMarshal               = errors.New("json marshal error")
 	ErrJSONUnmarshal             = errors.New("json unmarshal error")
 	ErrSessionHasNotInitialized  = errors.New("the session has not been initialized")
 	ErrLackSession               = errors.New("lack session")

--- a/pkg/json.go
+++ b/pkg/json.go
@@ -6,7 +6,12 @@ import (
 	"github.com/bytedance/sonic"
 )
 
-var sonicAPI = sonic.Config{UseInt64: true}.Froze() // Effectively prevents integer overflow
+var sonicAPI = sonic.Config{
+	UseInt64:                true, // Effectively prevents integer overflow
+	NoQuoteTextMarshaler:    true,
+	NoValidateJSONMarshaler: true,
+	NoValidateJSONSkip:      true,
+}.Froze()
 
 func JSONUnmarshal(data []byte, v interface{}) error {
 	if err := sonicAPI.Unmarshal(data, v); err != nil {

--- a/pkg/json_amd64.go
+++ b/pkg/json_amd64.go
@@ -1,3 +1,5 @@
+//go:build amd64
+
 package pkg
 
 import (
@@ -12,6 +14,14 @@ var sonicAPI = sonic.Config{
 	NoValidateJSONMarshaler: true,
 	NoValidateJSONSkip:      true,
 }.Froze()
+
+func JSONMarshal(v interface{}) ([]byte, error) {
+	data, err := sonicAPI.Marshal(v)
+	if err != nil {
+		return nil, fmt.Errorf("%w:, error: %+v", ErrJSONMarshal, err)
+	}
+	return data, nil
+}
 
 func JSONUnmarshal(data []byte, v interface{}) error {
 	if err := sonicAPI.Unmarshal(data, v); err != nil {

--- a/pkg/json_arm64.go
+++ b/pkg/json_arm64.go
@@ -1,0 +1,25 @@
+//go:build arm64
+
+package pkg
+
+import (
+	"fmt"
+
+	"github.com/go-json-experiment/json"
+	"github.com/go-json-experiment/json/jsontext"
+)
+
+func JSONMarshal(v interface{}) ([]byte, error) {
+	data, err := json.Marshal(v, jsontext.CanonicalizeRawInts(true))
+	if err != nil {
+		return nil, fmt.Errorf("%w:, error: %+v", ErrJSONMarshal, err)
+	}
+	return data, nil
+}
+
+func JSONUnmarshal(data []byte, v interface{}) error {
+	if err := json.Unmarshal(data, v); err != nil {
+		return fmt.Errorf("%w: data=%s, error: %+v", ErrJSONUnmarshal, data, err)
+	}
+	return nil
+}

--- a/server/send.go
+++ b/server/send.go
@@ -4,8 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/bytedance/sonic"
-
+	"github.com/ThinkInAIXYZ/go-mcp/pkg"
 	"github.com/ThinkInAIXYZ/go-mcp/protocol"
 )
 
@@ -18,7 +17,7 @@ func (server *Server) sendMsgWithRequest(ctx context.Context, sessionID string, 
 
 	req := protocol.NewJSONRPCRequest(requestID, method, params)
 
-	message, err := sonic.Marshal(req)
+	message, err := pkg.JSONMarshal(req)
 	if err != nil {
 		return err
 	}
@@ -32,7 +31,7 @@ func (server *Server) sendMsgWithRequest(ctx context.Context, sessionID string, 
 func (server *Server) sendMsgWithResponse(ctx context.Context, sessionID string, requestID protocol.RequestID, result protocol.ServerResponse) error {
 	resp := protocol.NewJSONRPCSuccessResponse(requestID, result)
 
-	message, err := sonic.Marshal(resp)
+	message, err := pkg.JSONMarshal(resp)
 	if err != nil {
 		return err
 	}
@@ -46,7 +45,7 @@ func (server *Server) sendMsgWithResponse(ctx context.Context, sessionID string,
 func (server *Server) sendMsgWithNotification(ctx context.Context, sessionID string, method protocol.Method, params protocol.ServerNotify) error {
 	notify := protocol.NewJSONRPCNotification(method, params)
 
-	message, err := sonic.Marshal(notify)
+	message, err := pkg.JSONMarshal(notify)
 	if err != nil {
 		return err
 	}
@@ -64,7 +63,7 @@ func (server *Server) sendMsgWithError(ctx context.Context, sessionID string, re
 
 	resp := protocol.NewJSONRPCErrorResponse(requestID, code, msg)
 
-	message, err := sonic.Marshal(resp)
+	message, err := pkg.JSONMarshal(resp)
 	if err != nil {
 		return err
 	}

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -7,7 +7,6 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/bytedance/sonic"
 	"github.com/google/uuid"
 
 	"github.com/ThinkInAIXYZ/go-mcp/pkg"
@@ -226,7 +225,7 @@ func TestServerHandle(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			uuid, _ := uuid.NewUUID()
 			req := protocol.NewJSONRPCRequest(uuid, tt.method, tt.request)
-			reqBytes, err := sonic.Marshal(req)
+			reqBytes, err := pkg.JSONMarshal(req)
 			if err != nil {
 				t.Fatalf("json Marshal: %+v", err)
 			}
@@ -458,7 +457,7 @@ func TestServerNotify(t *testing.T) {
 func testServerInit(t *testing.T, server *Server, in io.Writer, outScan *bufio.Scanner) {
 	uuid, _ := uuid.NewUUID()
 	req := protocol.NewJSONRPCRequest(uuid, protocol.Initialize, protocol.InitializeRequest{ProtocolVersion: protocol.Version})
-	reqBytes, err := sonic.Marshal(req)
+	reqBytes, err := pkg.JSONMarshal(req)
 	if err != nil {
 		t.Fatalf("json Marshal: %+v", err)
 	}
@@ -498,7 +497,7 @@ func testServerInit(t *testing.T, server *Server, in io.Writer, outScan *bufio.S
 	}
 
 	notify := protocol.NewJSONRPCNotification(protocol.NotificationInitialized, nil)
-	notifyBytes, err := sonic.Marshal(notify)
+	notifyBytes, err := pkg.JSONMarshal(notify)
 	if err != nil {
 		t.Fatalf("json Marshal: %+v", err)
 	}


### PR DESCRIPTION
## Description

Support the arm64 architecture on JSON implementations using https://github.com/go-json-experiment/json.

## Related Issue

None

## Type of change
Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
	- Upgrade `go` version to 1.24 on `go.mod` because `github.com/go-json-experiment/json` uses 1.24.
		- https://github.com/go-json-experiment/json/blob/d3c622f1b874954c355e60c8e6b6baa5f60d2fed/go.mod#L6
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring (no functional changes)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes