### PR TITLE
feat(protocol): add Enum field to Property and related tests

### DIFF
--- a/protocol/schema_generate_test.go
+++ b/protocol/schema_generate_test.go
@@ -1,0 +1,170 @@
+package protocol_test
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/ThinkInAIXYZ/go-mcp/protocol"
+)
+
+func TestGenerateSchemaFromReqStruct(t *testing.T) {
+	type testData struct {
+		String  string  `json:"string" description:"string"` // required
+		Number  float64 `json:"number,omitempty"`            // optional
+		Integer int     `json:"-"`                           // ignore
+
+		String4Enum  string  `json:"string4enum,omitempty" enum:"a,b,c"`       // enum
+		Integer4Enum int     `json:"integer4enum,omitempty" enum:"1,2,3"`      // enum
+		Number4Enum  float64 `json:"number4enum,omitempty" enum:"1.1,2.2,3.3"` // enum
+		Number4Enum2 int     `json:"number4enum2,omitempty" enum:"1,2,3"`      // enum
+	}
+
+	type testData4InvalidInteger4Enum struct {
+		Integer4Enum int `json:"integer4enum,omitempty" enum:"a,b,c"`
+	}
+
+	type testData4InvalidNumber4Enum struct {
+		Number4Enum float64 `json:"number4enum,omitempty" enum:"a,b,c"`
+	}
+
+	type testData4InvalidNumber4Enum2 struct {
+		Number4Enum2 float64 `json:"number4enum2,omitempty" enum:"a,b,c"`
+	}
+
+	type testData4InvalidEnum struct {
+		Enum byte `json:"enum,omitempty" enum:"a,b,c"`
+	}
+
+	type args struct {
+		v any
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    *protocol.InputSchema
+		wantErr bool
+	}{
+		{
+			name: "invalid type",
+			args: args{
+				v: 1,
+			},
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name: "struct type",
+			args: args{
+				v: testData{},
+			},
+			want: &protocol.InputSchema{
+				Type: protocol.Object,
+				Properties: map[string]*protocol.Property{
+					"string": {
+						Type:        protocol.String,
+						Description: "string",
+					},
+					"number": {
+						Type: protocol.Number,
+					},
+					"string4enum": {
+						Type: protocol.String,
+						Enum: []string{"a", "b", "c"},
+					},
+					"integer4enum": {
+						Type: protocol.Integer,
+						Enum: []string{"1", "2", "3"},
+					},
+					"number4enum": {
+						Type: protocol.Number,
+						Enum: []string{"1.1", "2.2", "3.3"},
+					},
+					"number4enum2": {
+						Type: protocol.Integer,
+						Enum: []string{"1", "2", "3"},
+					},
+				},
+				Required: []string{"string"},
+			},
+		},
+		{
+			name: "struct point type",
+			args: args{
+				v: &testData{},
+			},
+			want: &protocol.InputSchema{
+				Type: protocol.Object,
+				Properties: map[string]*protocol.Property{
+					"string": {
+						Type:        protocol.String,
+						Description: "string",
+					},
+					"number": {
+						Type: protocol.Number,
+					},
+					"string4enum": {
+						Type: protocol.String,
+						Enum: []string{"a", "b", "c"},
+					},
+					"integer4enum": {
+						Type: protocol.Integer,
+						Enum: []string{"1", "2", "3"},
+					},
+					"number4enum": {
+						Type: protocol.Number,
+						Enum: []string{"1.1", "2.2", "3.3"},
+					},
+					"number4enum2": {
+						Type: protocol.Integer,
+						Enum: []string{"1", "2", "3"},
+					},
+				},
+				Required: []string{"string"},
+			},
+		},
+		{
+			name: "invalid type for integer4Enum",
+			args: args{
+				v: &testData4InvalidInteger4Enum{},
+			},
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name: "invalid type for number4Enum",
+			args: args{
+				v: &testData4InvalidNumber4Enum{},
+			},
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name: "invalid type for number4Enum2",
+			args: args{
+				v: &testData4InvalidNumber4Enum2{},
+			},
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name: "invalid type for enum",
+			args: args{
+				v: &testData4InvalidEnum{},
+			},
+			want:    nil,
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := protocol.GenerateSchemaFromReqStruct(tt.args.v)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("GenerateSchemaFromReqStruct() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("GenerateSchemaFromReqStruct() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/protocol/schema_validate.go
+++ b/protocol/schema_validate.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
+	"strconv"
 
 	"github.com/ThinkInAIXYZ/go-mcp/pkg"
 )
@@ -50,28 +51,66 @@ func Validate(schema Property, data any) bool {
 	case Array:
 		return validateArray(schema, data)
 	case String:
-		_, ok := data.(string)
-		return ok
-	case Number: // float64 and int
-		_, ok := data.(float64)
-		if !ok {
-			_, ok = data.(int)
+		str, ok := data.(string)
+		if ok {
+			return validateEnumProperty[string](str, schema.Enum, func(value string, enumValue string) bool {
+				return value == enumValue
+			})
 		}
-		return ok
+		return false
+	case Number: // float64 and int
+		if num, ok := data.(float64); ok {
+			return validateEnumProperty[float64](num, schema.Enum, func(value float64, enumValue string) bool {
+				if enumNum, err := strconv.ParseFloat(enumValue, 64); err == nil && value == enumNum {
+					return true
+				}
+				return false
+			})
+		}
+		if num, ok := data.(int); ok {
+			return validateEnumProperty[int](num, schema.Enum, func(value int, enumValue string) bool {
+				if enumNum, err := strconv.Atoi(enumValue); err == nil && value == enumNum {
+					return true
+				}
+				return false
+			})
+		}
+		return false
 	case Boolean:
 		_, ok := data.(bool)
 		return ok
 	case Integer:
 		// Golang unmarshals all numbers as float64, so we need to check if the float64 is an integer
 		if num, ok := data.(float64); ok {
-			return num == float64(int64(num))
+			if num == float64(int64(num)) {
+				return validateEnumProperty[float64](num, schema.Enum, func(value float64, enumValue string) bool {
+					if enumNum, err := strconv.ParseFloat(enumValue, 64); err == nil && value == enumNum {
+						return true
+					}
+					return false
+				})
+			}
+			return false
 		}
-		_, ok := data.(int)
-		if ok {
-			return true
+
+		if num, ok := data.(int); ok {
+			return validateEnumProperty[int](num, schema.Enum, func(value int, enumValue string) bool {
+				if enumNum, err := strconv.Atoi(enumValue); err == nil && value == enumNum {
+					return true
+				}
+				return false
+			})
 		}
-		_, ok = data.(int64)
-		return ok
+
+		if num, ok := data.(int64); ok {
+			return validateEnumProperty[int64](num, schema.Enum, func(value int64, enumValue string) bool {
+				if enumNum, err := strconv.Atoi(enumValue); err == nil && value == int64(enumNum) {
+					return true
+				}
+				return false
+			})
+		}
+		return false
 	case Null:
 		return data == nil
 	default:
@@ -109,4 +148,13 @@ func validateArray(schema Property, data any) bool {
 		}
 	}
 	return true
+}
+
+func validateEnumProperty[T any](data T, enum []string, compareFunc func(T, string) bool) bool {
+	for _, enumValue := range enum {
+		if compareFunc(data, enumValue) {
+			return true
+		}
+	}
+	return len(enum) == 0
 }

--- a/protocol/schema_validate_test.go
+++ b/protocol/schema_validate_test.go
@@ -20,10 +20,18 @@ func Test_Validate(t *testing.T) {
 		// string integer number boolean
 		{"", args{data: "ABC", schema: protocol.Property{Type: protocol.String}}, true},
 		{"", args{data: 123, schema: protocol.Property{Type: protocol.String}}, false},
+		{"", args{data: "a", schema: protocol.Property{Type: protocol.String, Enum: []string{"a", "b", "c"}}}, true},
+		{"", args{data: "d", schema: protocol.Property{Type: protocol.String, Enum: []string{"a", "b", "c"}}}, false},
 		{"", args{data: 123, schema: protocol.Property{Type: protocol.Integer}}, true},
 		{"", args{data: 123.4, schema: protocol.Property{Type: protocol.Integer}}, false},
+		{"", args{data: 1, schema: protocol.Property{Type: protocol.Integer, Enum: []string{"1", "2", "3"}}}, true},
+		{"", args{data: 4, schema: protocol.Property{Type: protocol.Integer, Enum: []string{"1", "2", "3"}}}, false},
 		{"", args{data: "ABC", schema: protocol.Property{Type: protocol.Number}}, false},
 		{"", args{data: 123, schema: protocol.Property{Type: protocol.Number}}, true},
+		{"", args{data: 1.1, schema: protocol.Property{Type: protocol.Number, Enum: []string{"1.1", "2.2", "3.3"}}}, true},
+		{"", args{data: 4.4, schema: protocol.Property{Type: protocol.Number, Enum: []string{"1.1", "2.2", "3.3"}}}, false},
+		{"", args{data: 1, schema: protocol.Property{Type: protocol.Number, Enum: []string{"1", "2", "3"}}}, true},
+		{"", args{data: 4, schema: protocol.Property{Type: protocol.Number, Enum: []string{"1", "2", "3"}}}, false},
 		{"", args{data: false, schema: protocol.Property{Type: protocol.Boolean}}, true},
 		{"", args{data: 123, schema: protocol.Property{Type: protocol.Boolean}}, false},
 		{"", args{data: nil, schema: protocol.Property{Type: protocol.Null}}, true},
@@ -40,6 +48,26 @@ func Test_Validate(t *testing.T) {
 			},
 		}, false},
 		{"", args{
+			data: []any{"a"}, schema: protocol.Property{
+				Type: protocol.Array, Items: &protocol.Property{Type: protocol.String, Enum: []string{"a", "b", "c"}},
+			},
+		}, true},
+		{"", args{
+			data: []any{"a", "b", "c"}, schema: protocol.Property{
+				Type: protocol.Array, Items: &protocol.Property{Type: protocol.String, Enum: []string{"a", "b", "c"}},
+			},
+		}, true},
+		{"", args{
+			data: []any{"d"}, schema: protocol.Property{
+				Type: protocol.Array, Items: &protocol.Property{Type: protocol.String, Enum: []string{"a", "b", "c"}},
+			},
+		}, false},
+		{"", args{
+			data: []any{"a", "b", "c", "d"}, schema: protocol.Property{
+				Type: protocol.Array, Items: &protocol.Property{Type: protocol.String, Enum: []string{"a", "b", "c"}},
+			},
+		}, false},
+		{"", args{
 			data: []any{1, 2, 3}, schema: protocol.Property{
 				Type: protocol.Array, Items: &protocol.Property{Type: protocol.Integer},
 			},
@@ -47,6 +75,26 @@ func Test_Validate(t *testing.T) {
 		{"", args{
 			data: []any{1, 2, 3.4}, schema: protocol.Property{
 				Type: protocol.Array, Items: &protocol.Property{Type: protocol.Integer},
+			},
+		}, false},
+		{"", args{
+			data: []any{1}, schema: protocol.Property{
+				Type: protocol.Array, Items: &protocol.Property{Type: protocol.Integer, Enum: []string{"1", "2", "3"}},
+			},
+		}, true},
+		{"", args{
+			data: []any{1, 2, 3}, schema: protocol.Property{
+				Type: protocol.Array, Items: &protocol.Property{Type: protocol.Integer, Enum: []string{"1", "2", "3"}},
+			},
+		}, true},
+		{"", args{
+			data: []any{1, 2, 3, 4}, schema: protocol.Property{
+				Type: protocol.Array, Items: &protocol.Property{Type: protocol.Integer, Enum: []string{"1", "2", "3"}},
+			},
+		}, false},
+		{"", args{
+			data: []any{4}, schema: protocol.Property{
+				Type: protocol.Array, Items: &protocol.Property{Type: protocol.Integer, Enum: []string{"1", "2", "3"}},
 			},
 		}, false},
 		// object
@@ -78,6 +126,38 @@ func Test_Validate(t *testing.T) {
 				"number":  {Type: protocol.Number},
 				"boolean": {Type: protocol.Boolean},
 				"array":   {Type: protocol.Array, Items: &protocol.Property{Type: protocol.Number}},
+			},
+			Required: []string{"string"},
+		}}, false},
+		{"", args{data: map[string]any{
+			"string":     "a",
+			"integer":    1,
+			"number":     1.1,
+			"number4Int": 1,
+			"array":      []any{1, 2, 3},
+		}, schema: protocol.Property{
+			Type: protocol.ObjectT, Properties: map[string]*protocol.Property{
+				"string":     {Type: protocol.String, Enum: []string{"a", "b", "c"}},
+				"integer":    {Type: protocol.Integer, Enum: []string{"1", "2", "3"}},
+				"number":     {Type: protocol.Number, Enum: []string{"1.1", "2.2", "3.3"}},
+				"number4Int": {Type: protocol.Number, Enum: []string{"1", "2", "3"}},
+				"array":      {Type: protocol.Array, Items: &protocol.Property{Type: protocol.Number}, Enum: []string{"1", "2", "3"}},
+			},
+			Required: []string{"string"},
+		}}, true},
+		{"", args{data: map[string]any{
+			"string":     "d",
+			"integer":    4,
+			"number":     4.4,
+			"number4Int": 4,
+			"array":      []any{4},
+		}, schema: protocol.Property{
+			Type: protocol.ObjectT, Properties: map[string]*protocol.Property{
+				"string":     {Type: protocol.String, Enum: []string{"a", "b", "c"}},
+				"integer":    {Type: protocol.Integer, Enum: []string{"1", "2", "3"}},
+				"number":     {Type: protocol.Number, Enum: []string{"1.1", "2.2", "3.3"}},
+				"number4Int": {Type: protocol.Number, Enum: []string{"1", "2", "3"}},
+				"array":      {Type: protocol.Array, Items: &protocol.Property{Type: protocol.Number}, Enum: []string{"1", "2", "3"}},
 			},
 			Required: []string{"string"},
 		}}, false},
@@ -179,6 +259,11 @@ func TestVerifyAndUnmarshal(t *testing.T) {
 		String  string  `json:"string"`           // required
 		Number  float64 `json:"number,omitempty"` // optional
 		Integer int     `json:"-"`                // ignore
+
+		String4Enum  string  `json:"string4enum,omitempty" enum:"a,b,c"`       // enum
+		Integer4Enum int     `json:"integer4enum,omitempty" enum:"1,2,3"`      // enum
+		Number4Enum  float64 `json:"number4enum,omitempty" enum:"1.1,2.2,3.3"` // enum
+		Number4Enum2 int     `json:"number4enum2,omitempty" enum:"1,2,3"`      // enum
 	}
 	type args struct {
 		content json.RawMessage
@@ -218,6 +303,45 @@ func TestVerifyAndUnmarshal(t *testing.T) {
 			args: args{
 				content: json.RawMessage("{\"integer\":123.4}"),
 				v:       new(map[string]any),
+			},
+			wantErr: true,
+		},
+		{
+			name: "no error with enum",
+			args: args{
+				content: json.RawMessage("{\"string\":\"abc\",\"number\":123.4, \"string4enum\":\"a\",\"integer4enum\":1,\"number4enum\":1.1,\"number4enum2\":1}"),
+				v:       testData{},
+			},
+		},
+		{
+			name: "want a,b,c but d for string4enum",
+			args: args{
+				content: json.RawMessage("{\"string\":\"abc\",\"number\":123.4, \"string4enum\":\"d\"}"),
+				v:       testData{},
+			},
+			wantErr: true,
+		},
+		{
+			name: "want 1,2,3 but 4 for integer4enum",
+			args: args{
+				content: json.RawMessage("{\"string\":\"abc\",\"number\":123.4, \"integer4enum\":4}"),
+				v:       testData{},
+			},
+			wantErr: true,
+		},
+		{
+			name: "want 1.1,2.2,3.3 but 4.4 for number4enum",
+			args: args{
+				content: json.RawMessage("{\"string\":\"abc\",\"number\":123.4, \"number4enum\":4.4}"),
+				v:       testData{},
+			},
+			wantErr: true,
+		},
+		{
+			name: "want 1,2,3 but 4 for number4enum2",
+			args: args{
+				content: json.RawMessage("{\"string\":\"abc\",\"number\":123.4, \"number4enum2\":4}"),
+				v:       testData{},
 			},
 			wantErr: true,
 		},


### PR DESCRIPTION
## Description
This PR adds a new field `Enum []string` to the `Property` struct to support enumerated value constraints, as defined in the JSON Schema specification.    This is useful in scenarios where the value of a field needs to be restricted to a predefined set, such as limiting user-selected operation types or status values.

The following is an example provided in the official documentation, which includes the usage of the `enum` field:
```
{
  name: "analyze_csv",
  description: "Analyze a CSV file",
  inputSchema: {
    type: "object",
    properties: {
      filepath: { type: "string" },
      operations: {
        type: "array",
        items: {
          enum: ["sum", "average", "count"]
        }
      }
    }
  }
}
```

## Related Issue
None

## Type of change
Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring (no functional changes)

## How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

## Checklist:
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes