### PR TITLE
docs: Fix tool name in README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ func main() {
 	}
 
 	// Register time query tool
-	tool, err := protocol.NewTool("current time", "Get current time for specified timezone", TimeRequest{})
+	tool, err := protocol.NewTool("current_time", "Get current time for specified timezone", TimeRequest{})
 	if err != nil {
 		log.Fatalf("Failed to create tool: %v", err)
 		return

--- a/README_CN.md
+++ b/README_CN.md
@@ -118,7 +118,7 @@ func main() {
 	}
 
 	// 注册时间查询工具
-	tool, err := protocol.NewTool("current time", "获取指定时区的当前时间", TimeRequest{})
+	tool, err := protocol.NewTool("current_time", "获取指定时区的当前时间", TimeRequest{})
 	if err != nil {
 		log.Fatalf("创建工具失败: %v", err)
 		return


### PR DESCRIPTION
## Description
This PR fixes the example in README by correcting the registered tool name from "current time" to "current_time" to match the actual implementation. This ensures the documentation accurately reflects the correct usage.

## Related Issue
Fixes #(issue)

## Type of change
Please delete options that are not relevant.
- Documentation update

## How Has This Been Tested?
Manually verified by checking the consistency between the codebase and the updated README example. Confirmed that the tool name "current_time" is correctly registered in the implementation.
