### PR TITLE
fix: modify error naming and use snake_case naming

### DIFF
--- a/client/receive.go
+++ b/client/receive.go
@@ -88,13 +88,13 @@ func (client *Client) receiveRequest(ctx context.Context, request *protocol.JSON
 	if err != nil {
 		switch {
 		case errors.Is(err, pkg.ErrMethodNotSupport):
-			return client.sendMsgWithError(ctx, request.ID, protocol.METHOD_NOT_FOUND, err.Error())
+			return client.sendMsgWithError(ctx, request.ID, protocol.MethodNotFound, err.Error())
 		case errors.Is(err, pkg.ErrRequestInvalid):
-			return client.sendMsgWithError(ctx, request.ID, protocol.INVALID_REQUEST, err.Error())
+			return client.sendMsgWithError(ctx, request.ID, protocol.InvalidRequest, err.Error())
 		case errors.Is(err, pkg.ErrJSONUnmarshal):
-			return client.sendMsgWithError(ctx, request.ID, protocol.PARSE_ERROR, err.Error())
+			return client.sendMsgWithError(ctx, request.ID, protocol.ParseError, err.Error())
 		default:
-			return client.sendMsgWithError(ctx, request.ID, protocol.INTERNAL_ERROR, err.Error())
+			return client.sendMsgWithError(ctx, request.ID, protocol.InternalError, err.Error())
 		}
 	}
 	return client.sendMsgWithResponse(ctx, request.ID, result)

--- a/protocol/jsonrpc.go
+++ b/protocol/jsonrpc.go
@@ -10,16 +10,11 @@ const jsonrpcVersion = "2.0"
 
 // Standard JSON-RPC error codes
 const (
-	//nolint:revive
-	PARSE_ERROR = -32700 // Invalid JSON
-	//nolint:revive
-	INVALID_REQUEST = -32600 // The JSON sent is not a valid Request object
-	//nolint:revive
-	METHOD_NOT_FOUND = -32601 // The method does not exist / is not available
-	//nolint:revive
-	INVALID_PARAMS = -32602 // Invalid method parameter(s)
-	//nolint:revive
-	INTERNAL_ERROR = -32603 // Internal JSON-RPC error
+	ParseError     = -32700 // Invalid JSON
+	InvalidRequest = -32600 // The JSON sent is not a valid Request object
+	MethodNotFound = -32601 // The method does not exist / is not available
+	InvalidParams  = -32602 // Invalid method parameter(s)
+	InternalError  = -32603 // Internal JSON-RPC error
 
 	// 可以定义自己的错误代码，范围在-32000 以上。
 )

--- a/server/receive.go
+++ b/server/receive.go
@@ -135,13 +135,13 @@ func (server *Server) receiveRequest(sessionID string, request *protocol.JSONRPC
 	if err != nil {
 		switch {
 		case errors.Is(err, pkg.ErrMethodNotSupport):
-			return server.sendMsgWithError(ctx, sessionID, request.ID, protocol.METHOD_NOT_FOUND, err.Error())
+			return server.sendMsgWithError(ctx, sessionID, request.ID, protocol.MethodNotFound, err.Error())
 		case errors.Is(err, pkg.ErrRequestInvalid):
-			return server.sendMsgWithError(ctx, sessionID, request.ID, protocol.INVALID_REQUEST, err.Error())
+			return server.sendMsgWithError(ctx, sessionID, request.ID, protocol.InvalidRequest, err.Error())
 		case errors.Is(err, pkg.ErrJSONUnmarshal):
-			return server.sendMsgWithError(ctx, sessionID, request.ID, protocol.PARSE_ERROR, err.Error())
+			return server.sendMsgWithError(ctx, sessionID, request.ID, protocol.ParseError, err.Error())
 		default:
-			return server.sendMsgWithError(ctx, sessionID, request.ID, protocol.INTERNAL_ERROR, err.Error())
+			return server.sendMsgWithError(ctx, sessionID, request.ID, protocol.InternalError, err.Error())
 		}
 	}
 	return server.sendMsgWithResponse(ctx, sessionID, request.ID, result)


### PR DESCRIPTION
## Description
modify error naming and use snake_case naming, such as: 
PARSE_ERROR => ParseError

## Related Issue
None

## Type of change
Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [√] Code refactoring (no functional changes)