### PR TITLE
feat: enhance response handling for JSON content types

### DIFF
--- a/transport/streamable_http_client.go
+++ b/transport/streamable_http_client.go
@@ -147,9 +147,6 @@ func (t *streamableHTTPClientTransport) Send(ctx context.Context, msg Message) e
 		}()
 		return nil
 	case isJSONContentType(contentType):
-		if resp.StatusCode == http.StatusAccepted { // Handle immediate JSON response
-			return nil
-		}
 		body, err := io.ReadAll(resp.Body)
 		if err != nil {
 			return fmt.Errorf("failed to read response body: %w", err)
@@ -165,9 +162,7 @@ func (t *streamableHTTPClientTransport) Send(ctx context.Context, msg Message) e
 
 // isJSONContentType checks if the content type is JSON, regardless of additional parameters
 func isJSONContentType(contentType string) bool {
-	return strings.HasPrefix(contentType, "application/json") ||
-		strings.HasPrefix(contentType, "application/hal+json") ||
-		strings.HasPrefix(contentType, "application/problem+json")
+	return strings.HasPrefix(contentType, "application/json")
 }
 
 func (t *streamableHTTPClientTransport) startSSEStream() {


### PR DESCRIPTION
## Description
在我使用higress market提供的mcp Server服务的时候，我遇到了基于go-mcp开发的mcp-client无法创建的情况，所以我就把streamable_http_client 里面的内容修改了下，能够成功调用了。