### PR TITLE
fix streamableHTTP for timer

### DIFF
--- a/transport/streamable_http_client.go
+++ b/transport/streamable_http_client.go
@@ -159,11 +159,13 @@ func (t *streamableHTTPClientTransport) Send(ctx context.Context, msg Message) e
 }
 
 func (t *streamableHTTPClientTransport) startSSEStream() {
+	timer := time.NewTimer(time.Second)
+	defer timer.Stop()
 	for {
 		select {
 		case <-t.ctx.Done():
 			return
-		case <-time.After(time.Second):
+		case <-timer.C:
 			sessionID := t.sessionID.Load()
 			if sessionID == "" {
 				continue // Try again after 1 second, waiting for the POST request to initialize the SessionID to complete


### PR DESCRIPTION
## Description
在startSSEStream方法的循环中，每次迭代都会创建一个新的time.After定时器。如果循环迭代非常频繁，这可能会导致不必要的性能开销。
提取出time.Ticker可以定期发送信号，而不是每次都需要创建一个新的定时器。这样可以减少垃圾回收的压力。