### PR TITLE
Fix the handleTimeRequest function of two readmes. the sample of hand…

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,12 @@ func main() {
 	if err != nil {
 		log.Fatalf("Failed to list tools: %v", err)
 	}
-	log.Printf("Available tools: %+v", tools)
+	
+	jsonBytes, err := json.MarshalIndent(tools, "", "  ")
+	if err != nil {
+		log.Fatalf("Failed to marshal tools: %v", err)
+	}
+	fmt.Println(string(jsonBytes))
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ func main() {
 	}
 }
 
-func handleTimeRequest(req *protocol.CallToolRequest) (*protocol.CallToolResult, error) {
+func handleTimeRequest(_ context.Context,req *protocol.CallToolRequest) (*protocol.CallToolResult, error) {
 	var timeReq TimeRequest
 	if err := protocol.VerifyAndUnmarshal(req.RawArguments, &timeReq); err != nil {
 		return nil, err

--- a/README_CN.md
+++ b/README_CN.md
@@ -80,9 +80,13 @@ func main() {
 	if err != nil {
 		log.Fatalf("获取工具列表失败: %v", err)
 	}
-	log.Printf("可用工具: %+v", tools)
+	
+	jsonBytes, err := json.MarshalIndent(tools, "", "  ")
+	if err != nil {
+		log.Fatalf("Failed to marshal tools: %v", err)
+	}
+	fmt.Println(string(jsonBytes))
 }
-
 ```
 
 ### 服务器示例

--- a/README_CN.md
+++ b/README_CN.md
@@ -131,7 +131,7 @@ func main() {
 	}
 }
 
-func handleTimeRequest(req *protocol.CallToolRequest) (*protocol.CallToolResult, error) {
+func handleTimeRequest(_ context.Context,req *protocol.CallToolRequest) (*protocol.CallToolResult, error) {
 	var timeReq TimeRequest
 	if err := protocol.VerifyAndUnmarshal(req.RawArguments, &timeReq); err != nil {
 		return nil, err


### PR DESCRIPTION
…leTimeRequest "Missing _ context.Context parameter"

## Description
./main.go:58:31: cannot use handleTimeRequest (value of type func(req *protocol.CallToolRequest) (*protocol.CallToolResult, error)) as server.ToolHandlerFunc value in argument to mcpServer.RegisterTool

`handleTimeRequest "Missing _ context.Context parameter"`
## Related Issue
Fixes #(issue)

## Type of change
Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring (no functional changes)

## How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

## Checklist:
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes