### PR TITLE
[FEATURE] Support nested anonymous struct member in the schema

### DIFF
--- a/protocol/schema_generate_test.go
+++ b/protocol/schema_generate_test.go
@@ -17,6 +17,11 @@ func TestGenerateSchemaFromReqStruct(t *testing.T) {
 		Number4Enum2 int     `json:"number4enum2,omitempty" enum:"1,2,3"`      // enum
 	}
 
+	type anonymousTestDataWrapper struct {
+		testData
+		ExtraField string `json:"extraField,omitempty" description:"extra string enum" enum:"a,b,c"`
+	}
+
 	type testData4InvalidInteger4Enum struct {
 		Integer4Enum int `json:"integer4enum,omitempty" enum:"a,b,c"`
 	}
@@ -119,6 +124,57 @@ func TestGenerateSchemaFromReqStruct(t *testing.T) {
 				},
 				Required: []string{"string"},
 			},
+		},
+		{
+			name: "anonymous nested struct type",
+			args: args{
+				v: anonymousTestDataWrapper{},
+			},
+			want: &InputSchema{
+				Type: Object,
+				Properties: map[string]*Property{
+					"string": {
+						Type:        String,
+						Description: "string",
+					},
+					"extraField": {
+						Type:        String,
+						Description: "extra string enum",
+						Enum:        []string{"a", "b", "c"},
+					},
+					"number": {
+						Type: Number,
+					},
+					"string4enum": {
+						Type: String,
+						Enum: []string{"a", "b", "c"},
+					},
+					"integer4enum": {
+						Type: Integer,
+						Enum: []string{"1", "2", "3"},
+					},
+					"number4enum": {
+						Type: Number,
+						Enum: []string{"1.1", "2.2", "3.3"},
+					},
+					"number4enum2": {
+						Type: Integer,
+						Enum: []string{"1", "2", "3"},
+					},
+				},
+				Required: []string{"string"},
+			},
+		},
+		{
+			name: "anonymous member collision",
+			args: args{
+				v: struct {
+					testData
+					String string `json:"string" description:"string"` // conflict with testData.string
+				}{},
+			},
+			want:    nil,
+			wantErr: true,
 		},
 		{
 			name: "invalid type for integer4Enum",


### PR DESCRIPTION
## Description
This PR adds support for anonymous struct member by flattening their members into the containing struct.
This is done using recursion in reflectSchemaByObject().
Note - Although allowed in golang, I didn't allow members of the inner struct to collide with the containing structs.

## Related Issue
Fixes #(issue)

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
Added two UT:
1) Successful merge of  nested struct
2) Failed schema creation due to member collision

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes