### PR TITLE
feat: GetSessionIDFromCtx

### DIFF
--- a/server/call.go
+++ b/server/call.go
@@ -12,7 +12,7 @@ import (
 )
 
 func (server *Server) Ping(ctx context.Context, request *protocol.PingRequest) (*protocol.PingResult, error) {
-	sessionID, err := getSessionIDFromCtx(ctx)
+	sessionID, err := GetSessionIDFromCtx(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -30,7 +30,7 @@ func (server *Server) Ping(ctx context.Context, request *protocol.PingRequest) (
 }
 
 func (server *Server) Sampling(ctx context.Context, request *protocol.CreateMessageRequest) (*protocol.CreateMessageResult, error) {
-	sessionID, err := getSessionIDFromCtx(ctx)
+	sessionID, err := GetSessionIDFromCtx(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/server/context.go
+++ b/server/context.go
@@ -11,14 +11,10 @@ func setSessionIDToCtx(ctx context.Context, sessionID string) context.Context {
 	return context.WithValue(ctx, sessionIDKey{}, sessionID)
 }
 
-func getSessionIDFromCtx(ctx context.Context) (string, error) {
+func GetSessionIDFromCtx(ctx context.Context) (string, error) {
 	sessionID := ctx.Value(sessionIDKey{})
 	if sessionID == nil {
 		return "", errors.New("no session id found")
 	}
 	return sessionID.(string), nil
-}
-
-func GetSessionIDFromCtx(ctx context.Context) (string, error) {
-	return getSessionIDFromCtx(ctx)
 }

--- a/server/context.go
+++ b/server/context.go
@@ -18,3 +18,7 @@ func getSessionIDFromCtx(ctx context.Context) (string, error) {
 	}
 	return sessionID.(string), nil
 }
+
+func GetSessionIDFromCtx(ctx context.Context) (string, error) {
+	return getSessionIDFromCtx(ctx)
+}


### PR DESCRIPTION
## Description
Make `getSessionIDFromCtx` public

This is useful for tool implementations that need to be aware of the session (e.g.: in order to manage session-scoped caches)

**Note:** I know this could be achieved with a custom session ID generation logic (using `server.WithGenSessionIDFunc()`), but this should offer a shortcut to get there in case people are just interested in knowing the session ID.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
`make test`

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes