### PR TITLE
refactor: unify method receivers on ResourceTemplate to use pointer receivers

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -101,7 +101,7 @@ func TestClientCall(t *testing.T) {
 				return client.ListResourceTemplates(context.Background())
 			},
 			request:          protocol.NewListResourceTemplatesRequest(),
-			expectedResponse: protocol.NewListResourceTemplatesResult([]protocol.ResourceTemplate{{Name: "template1"}, {Name: "template2"}}, ""),
+			expectedResponse: protocol.NewListResourceTemplatesResult([]*protocol.ResourceTemplate{{Name: "template1"}, {Name: "template2"}}, ""),
 		},
 		{
 			name: "test_subscribe_resource_change",

--- a/protocol/resources.go
+++ b/protocol/resources.go
@@ -81,7 +81,7 @@ func (r *ReadResourceResult) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-// Resource  A known resource that the server is capable of reading.
+// Resource A known resource that the server is capable of reading.
 type Resource struct {
 	Annotated
 	// Name A human-readable name for this resource. This can be used by clients to populate UI elements.
@@ -110,7 +110,7 @@ type ResourceTemplate struct {
 	MimeType          string                `json:"mimeType,omitempty"`
 }
 
-func (t ResourceTemplate) GetName() string {
+func (t *ResourceTemplate) GetName() string {
 	return t.Name
 }
 

--- a/protocol/resources.go
+++ b/protocol/resources.go
@@ -31,8 +31,8 @@ type ListResourceTemplatesRequest struct {
 
 // ListResourceTemplatesResult represents the response to a list resource templates request
 type ListResourceTemplatesResult struct {
-	ResourceTemplates []ResourceTemplate `json:"resourceTemplates"`
-	NextCursor        Cursor             `json:"nextCursor,omitempty"`
+	ResourceTemplates []*ResourceTemplate `json:"resourceTemplates"`
+	NextCursor        Cursor              `json:"nextCursor,omitempty"`
 }
 
 // ReadResourceRequest represents a request to read a specific resource
@@ -307,7 +307,7 @@ func NewListResourceTemplatesRequest() *ListResourceTemplatesRequest {
 }
 
 // NewListResourceTemplatesResult creates a new list resource templates response
-func NewListResourceTemplatesResult(templates []ResourceTemplate, nextCursor Cursor) *ListResourceTemplatesResult {
+func NewListResourceTemplatesResult(templates []*ResourceTemplate, nextCursor Cursor) *ListResourceTemplatesResult {
 	return &ListResourceTemplatesResult{
 		ResourceTemplates: templates,
 		NextCursor:        nextCursor,

--- a/server/handle.go
+++ b/server/handle.go
@@ -131,13 +131,13 @@ func (server *Server) handleRequestWithListResourceTemplates(rawParams json.RawM
 		}
 	}
 
-	templates := make([]protocol.ResourceTemplate, 0)
+	templates := make([]*protocol.ResourceTemplate, 0)
 	server.resourceTemplates.Range(func(_ string, entry *resourceTemplateEntry) bool {
-		templates = append(templates, *entry.resourceTemplate)
+		templates = append(templates, entry.resourceTemplate)
 		return true
 	})
 	if server.paginationLimit > 0 {
-		resourcesToReturn, nextCursor, err := protocol.PaginationLimit[protocol.ResourceTemplate](templates, request.Cursor, server.paginationLimit)
+		resourcesToReturn, nextCursor, err := protocol.PaginationLimit[*protocol.ResourceTemplate](templates, request.Cursor, server.paginationLimit)
 		return &protocol.ListResourceTemplatesResult{
 			ResourceTemplates: resourcesToReturn,
 			NextCursor:        nextCursor,

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -203,7 +203,7 @@ func TestServerHandle(t *testing.T) {
 			method:  protocol.ResourceListTemplates,
 			request: protocol.ListResourceTemplatesRequest{},
 			expectedResponse: protocol.ListResourceTemplatesResult{
-				ResourceTemplates: []protocol.ResourceTemplate{*testResourceTemplate},
+				ResourceTemplates: []*protocol.ResourceTemplate{testResourceTemplate},
 			},
 		},
 		{


### PR DESCRIPTION
## Description

The `ResourceTemplate` struct previously used a mix of value and pointer receivers across its methods. This is discouraged by Go best practices, as it can lead to inconsistent behavior and confusion for developers.

## Related Issue
Fixes #(issue)

## Type of change
Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring (no functional changes)

## How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

## Checklist:
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes