### PR TITLE
fix initialize protocol version negotiation

### DIFF
--- a/server/handle.go
+++ b/server/handle.go
@@ -22,10 +22,11 @@ func (server *Server) handleRequestWithInitialize(ctx context.Context, sessionID
 		return nil, err
 	}
 
-	if _, ok := protocol.SupportedVersion[request.ProtocolVersion]; !ok {
-		return nil, fmt.Errorf("protocol version not supported, supported lastest version is %v", protocol.Version)
-	}
+	// Version negotiation: if client's version is supported, use it; otherwise use server's latest version
 	protocolVersion := request.ProtocolVersion
+	if _, ok := protocol.SupportedVersion[request.ProtocolVersion]; !ok {
+		protocolVersion = protocol.Version
+	}
 
 	if midVar, ok := ctx.Value(transport.SessionIDForReturnKey{}).(*transport.SessionIDForReturn); ok {
 		sessionID = server.sessionManager.CreateSession(ctx)


### PR DESCRIPTION
According to the spec: https://modelcontextprotocol.info/specification/draft/basic/lifecycle/#version-negotiation

"If the server supports the requested protocol version, it MUST respond with the same version. Otherwise, the server MUST respond with another protocol version it supports. This SHOULD be the latest version supported by the server."