### PR TITLE
fix: ignore session ID header in stateless mode

### DIFF
--- a/transport/streamable_http_server.go
+++ b/transport/streamable_http_server.go
@@ -221,7 +221,14 @@ func (t *streamableHTTPServerTransport) handlePost(w http.ResponseWriter, r *htt
 		ctx = context.WithValue(ctx, SessionIDForReturnKey{}, &SessionIDForReturn{})
 	}
 
-	outputMsgCh, err := t.receiver.Receive(ctx, r.Header.Get(sessionIDHeader), bs)
+	// In stateless mode, ignore any session ID sent by the client (e.g. from MCP proxies)
+	// to avoid rejecting requests with stale or unrecognized session headers.
+	sessionID := ""
+	if t.stateMode == Stateful {
+		sessionID = r.Header.Get(sessionIDHeader)
+	}
+
+	outputMsgCh, err := t.receiver.Receive(ctx, sessionID, bs)
 	if err != nil {
 		if errors.Is(err, pkg.ErrSessionClosed) {
 			t.writeError(w, http.StatusNotFound, fmt.Sprintf("Failed to receive: %v", err))


### PR DESCRIPTION
## Problem

In stateless mode, the server never creates sessions and never returns `Mcp-Session-Id` headers in responses. However, `handlePost` unconditionally forwards the client's `Mcp-Session-Id` header to `server.receive()`:

```go
outputMsgCh, err := t.receiver.Receive(ctx, r.Header.Get(sessionIDHeader), bs)
```

In `receive()`, any non-empty session ID is validated against the session manager:

```go
if sessionID != "" && !server.sessionManager.IsActiveSession(sessionID) {
    return nil, pkg.ErrLackSession
}
```

Since the stateless server never creates sessions, `IsActiveSession()` always returns `false` for any session ID. This means **every request that carries a `Mcp-Session-Id` header is rejected** before any tool execution occurs.

This is a real issue when MCP proxies (e.g. TrueFoundry, or any HTTP reverse proxy) sit between the client and server and transparently forward all headers — the stateless server rejects their requests with `ErrLackSession`.

## Fix

Only read and forward the `Mcp-Session-Id` header in stateful mode. In stateless mode, pass an empty session ID to `Receive()`, skipping the session validation entirely:

```go
sessionID := ""
if t.stateMode == Stateful {
    sessionID = r.Header.Get(sessionIDHeader)
}
outputMsgCh, err := t.receiver.Receive(ctx, sessionID, bs)
```

This is consistent with the existing behavior in `handleGet`, which already returns early in stateless mode before reaching any session logic.

## Testing

All existing tests pass. The change is a no-op for stateful servers (behavior unchanged).