### PR TITLE
fix: use HasPrefix for text/event-stream content-type check

### DIFF
--- a/transport/streamable_http_client.go
+++ b/transport/streamable_http_client.go
@@ -121,7 +121,7 @@ func (t *streamableHTTPClientTransport) Send(ctx context.Context, msg Message) e
 	if err != nil {
 		return fmt.Errorf("failed to send message: %w", err)
 	}
-	if resp.Header.Get("Content-Type") != "text/event-stream" {
+	if !strings.HasPrefix(resp.Header.Get("Content-Type"), "text/event-stream") {
 		defer resp.Body.Close()
 	}
 
@@ -148,7 +148,7 @@ func (t *streamableHTTPClientTransport) Send(ctx context.Context, msg Message) e
 	contentType := resp.Header.Get("Content-Type")
 	// Handle different response types
 	switch {
-	case contentType == "text/event-stream":
+	case strings.HasPrefix(contentType, "text/event-stream"):
 		go func() {
 			defer pkg.Recover()
 


### PR DESCRIPTION
## What type of PR is this?

bug fix

## What this PR does

Fix the `unexpected content type: text/event-stream; charset=utf-8` error when servers or reverse proxies (e.g., nginx) append `; charset=utf-8` to the `Content-Type` header.

## Root Cause

In `transport/streamable_http_client.go`, the client checks `Content-Type` for `text/event-stream` using strict equality (`==`). When the server returns `text/event-stream; charset=utf-8` (which is valid HTTP), the check fails and falls into the `default` case, producing the error.

The `application/json` check already uses `strings.HasPrefix`, but `text/event-stream` did not.

## Changes

- Line 124: Changed strict equality to `!strings.HasPrefix(resp.Header.Get("Content-Type"), "text/event-stream")`
- Line 151: Changed strict equality to `strings.HasPrefix(contentType, "text/event-stream")`

## Which issue(s) this PR fixes

Fixes #200
