### PR TITLE
fix: stateless transport should ignore unmatched cancellations and reject DELETE with 405

### DIFF
--- a/server/cancelled_stateless_test.go
+++ b/server/cancelled_stateless_test.go
@@ -1,0 +1,29 @@
+package server
+
+import (
+	"encoding/json"
+	"io"
+	"testing"
+
+	"github.com/ThinkInAIXYZ/go-mcp/transport"
+)
+
+// A cancellation that cannot be matched to an in-progress request (e.g. in
+// stateless mode, where there is no session to look it up in) is fire-and-forget
+// per the MCP cancellation spec and must be ignored, not answered with an error.
+func TestStatelessCancelledNotificationIgnored(t *testing.T) {
+	reader, _ := io.Pipe()
+	_, writer := io.Pipe()
+
+	s, err := NewServer(transport.NewMockServerTransport(reader, writer))
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+
+	params := json.RawMessage(`{"requestId":"123","reason":"Request timed out"}`)
+
+	// sessionID "" => no session (stateless); must be ignored, returning nil.
+	if err := s.handleNotifyWithCancelled("", params); err != nil {
+		t.Fatalf("stateless cancelled notification: got err %v, want nil (ignored)", err)
+	}
+}

--- a/server/handle.go
+++ b/server/handle.go
@@ -300,7 +300,10 @@ func (server *Server) handleNotifyWithCancelled(sessionID string, rawParams json
 
 	s, ok := server.sessionManager.GetSession(sessionID)
 	if !ok {
-		return pkg.ErrLackSession
+		// No session to match the request against (e.g. stateless mode). Per the
+		// cancellation spec a notification referencing an unknown request is
+		// fire-and-forget and must be ignored, not answered with an error.
+		return nil
 	}
 
 	cancel, ok := s.GetClientReqID2cancelFunc().Get(fmt.Sprint(params.RequestID))

--- a/transport/streamable_http_server.go
+++ b/transport/streamable_http_server.go
@@ -360,6 +360,11 @@ func (t *streamableHTTPServerTransport) handleGet(w http.ResponseWriter, r *http
 }
 
 func (t *streamableHTTPServerTransport) handleDelete(w http.ResponseWriter, r *http.Request) {
+	if t.stateMode == Stateless {
+		t.writeError(w, http.StatusMethodNotAllowed, "server is stateless, does not support session termination")
+		return
+	}
+
 	sessionID := r.Header.Get("Mcp-Session-Id")
 	if sessionID == "" {
 		t.writeError(w, http.StatusBadRequest, "Missing session ID")

--- a/transport/streamable_http_stateless_test.go
+++ b/transport/streamable_http_stateless_test.go
@@ -1,0 +1,27 @@
+package transport
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// In stateless mode there are no sessions to terminate, so a DELETE to the MCP
+// endpoint must respond 405 Method Not Allowed (per the Streamable HTTP session
+// management spec), rather than 400 "Missing session ID".
+func TestStatelessDeleteReturnsMethodNotAllowed(t *testing.T) {
+	_, handler, err := NewStreamableHTTPServerTransportAndHandler(
+		WithStreamableHTTPServerTransportAndHandlerOptionStateMode(Stateless),
+	)
+	if err != nil {
+		t.Fatalf("NewStreamableHTTPServerTransportAndHandler: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodDelete, "/mcp", nil)
+	w := httptest.NewRecorder()
+	handler.HandleMCP().ServeHTTP(w, req)
+
+	if w.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("stateless DELETE: got status %d, want %d", w.Code, http.StatusMethodNotAllowed)
+	}
+}


### PR DESCRIPTION
## Problem

In stateless mode (`StateMode: Stateless`), two messages that are part of normal MCP client operation are rejected with HTTP `400`, even though the rest of the transport works:

**1. `notifications/cancelled` → `400 "Failed to receive: lack session"`**
When a client times out or aborts a request it sends a cancellation. `handleNotifyWithCancelled` looks up the session to find the in-flight request; in stateless mode `sessionID == ""`, so `GetSession` fails and it returns `ErrLackSession`. But per the [cancellation spec](https://modelcontextprotocol.io/specification/2025-06-18/basic/utilities/cancellation), a cancellation that can't be matched is fire-and-forget and **should be ignored**:

> Invalid cancellation notifications **SHOULD** be ignored: Unknown request IDs … This maintains the "fire and forget" nature of notifications.

The function already returns `nil` when the `requestID` is unknown — it should do the same when there is no session to look it up in.

**2. `DELETE` (session termination) → `400 "Missing session ID"`**
A stateless server issues no session id, so clients have none to send on the `DELETE` they emit at disconnect. The [transport spec](https://modelcontextprotocol.io/specification/2025-06-18/basic/transports#session-management) says the response for a server that does not support client-terminated sessions is `405`:

> The server **MAY** respond to this request with HTTP 405 Method Not Allowed, indicating that the server does not allow clients to terminate sessions.

`400` is specified only for servers that *require* a session id. This also mirrors how `handleGet` already returns `405` in stateless mode.

In practice these produce a steady stream of `400`s on a stateless MCP endpoint, and some clients react to the cancellation `400` by tearing down and reconnecting in a loop.

## Fix

- `server/handle.go` — `handleNotifyWithCancelled`: when there is no session, ignore (return `nil`) instead of `ErrLackSession`. The transport then returns `202 Accepted`, per the spec for an accepted notification.
- `transport/streamable_http_server.go` — `handleDelete`: return `405 Method Not Allowed` in stateless mode (mirrors `handleGet`).

## Tests

Added `TestStatelessCancelledNotificationIgnored` (server) and `TestStatelessDeleteReturnsMethodNotAllowed` (transport). Full `server` and `transport` suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
