### PR TITLE
fix: resolve misspell lint failure in stateless cancellation test

### DIFF
--- a/server/cancelled_stateless_test.go
+++ b/server/cancelled_stateless_test.go
@@ -24,6 +24,6 @@ func TestStatelessCancelledNotificationIgnored(t *testing.T) {
 
 	// sessionID "" => no session (stateless); must be ignored, returning nil.
 	if err := s.handleNotifyWithCancelled("", params); err != nil {
-		t.Fatalf("stateless cancelled notification: got err %v, want nil (ignored)", err)
+		t.Fatalf("stateless cancellation notification: got err %v, want nil (ignored)", err)
 	}
 }


### PR DESCRIPTION
Follow-up to #202, which introduced a `misspell` lint failure on `main`:

```
server/cancelled_stateless_test.go:27:23: `cancelled` is a misspelling of `canceled` (misspell)
```

The `misspell` linter flags the British spelling "cancelled" in string literals (it wants the US "canceled" — the same reason `NotificationCancelled` carries a `//nolint:misspell`). This reworks the test's failure message to use "cancellation", which the linter accepts, rather than adding a `nolint`.

No behavior change; `go test ./server/...` passes and `misspell` is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
